### PR TITLE
Bump to 1.1.8, add basic CI setup

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,73 @@
+name: Publishing Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: snap
+
+      - name: Install snap
+        run: |
+          sudo snap install --dangerous --classic ${{ needs.build.outputs.snap }}
+
+      - name: Basic test (invoke `terraform --version`)
+        run: terraform --version
+
+      - name: Setup MicroK8s
+        uses: balchua/microk8s-actions@v0.2.1
+        with:
+          channel: latest/stable
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Test snap (deploy on MicroK8s)
+        run: |
+          cd test
+          terraform init
+          terraform apply -auto-approve
+          kubectl get ns snaptest
+
+  # # Uncomment when the snap ownership is transferred and CI is set up
+  # publish:
+  #   needs: [build, test]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: snap
+
+  #     - name: Release snap to branch
+  #       uses: snapcore/action-publish@v1
+  #       with:
+  #         store_login: ${{ secrets.STORE_LOGIN }}
+  #         snap: ${{ needs.build.outputs.snap }}
+  #         release: edge

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,75 @@
+name: Pull Request Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: snap
+
+      - name: Install snap
+        run: |
+          sudo snap install --dangerous --classic ${{ needs.build.outputs.snap }}
+
+      - name: Basic test (invoke `terraform --version`)
+        run: terraform --version
+
+      - name: Setup MicroK8s
+        uses: balchua/microk8s-actions@v0.2.1
+        with:
+          channel: latest/stable
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Test snap (deploy on MicroK8s)
+        run: |
+          cd test
+          terraform init
+          terraform apply -auto-approve
+          kubectl get ns snaptest
+
+  # # Uncomment when the snap ownership is transferred and CI is set up
+  # publish:
+  #   needs: [build, test]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: snap
+
+  #     - name: Release snap to branch
+  #       uses: snapcore/action-publish@v1
+  #       with:
+  #         store_login: ${{ secrets.STORE_LOGIN }}
+  #         snap: ${{ needs.build.outputs.snap }}
+  #         release: edge/pr-${{ env.PR }}
+  #       env:
+  #         PR: ${{ github.event.number }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: terraform
-version: "1.1.7"
+version: "1.1.8"
 summary: Terraform enables you to create, change, and improve infrastructure.
 description: |
   Terraform enables you to safely and predictably create, change, and improve

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,9 @@
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+resource "kubernetes_namespace" "snaptest" {
+  metadata {
+    name = "snaptest"
+  }
+}


### PR DESCRIPTION
This PR bumps the Terraform version to v1.18.

It also adds two Github Actions:

- The first runs on PRs targeting the `main` branch. It builds the snap, installs it and invokes `terraform --version` as a basic smoke test. It will then publish the charm to `latest/edge/pr-<PR_NUMBER>`.
- The second is the same as above, but only runs on merges to `main`, and publishes to `latest/edge`