### PR TITLE
Skip Duplicate Jobs

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -50,9 +50,10 @@ jobs:
           LATEST="${{ needs.check-upstream.outputs.release }}"
           # Get the current version from the repo
           CURRENT="$(grep -Po "^version: \"\K[0-9]+\.[0-9]+\.[0-9]+" snap/snapcraft.yaml)"
-          # Update the snapcraft.yaml
+          # Update the snapcraft.yaml (strip the leading 'v' from the LATEST version)
           sed -i "s/^version: \"$CURRENT\"/version: \"${LATEST/v/}\"/g" snap/snapcraft.yaml
 
+      # We use a Github App and token to allow Github Actions to run properly on the created PR.
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,37 @@
+name: Build and Test
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build snap locally
+        uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: Upload locally built snap artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.snapcraft.outputs.snap }}
+          path: ${{ steps.snapcraft.outputs.snap }}
+
+      - name: Install snap & invoke terraform
+        run: |
+          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
+          terraform --version
+
+      - name: Setup MicroK8s
+        uses: balchua/microk8s-actions@v0.2.1
+        with:
+          channel: latest/stable
+
+      - name: Test snap - kubernetes provider
+        run: |
+          cd test
+          terraform init
+          terraform apply -auto-approve
+          kubectl get ns snaptest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install snap & invoke terraform
         run: |
-          sudo snap install --dangerous --classic ${{ needs.build.outputs.snap }}
+          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
           terraform --version
 
       - name: Setup MicroK8s

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,40 +9,25 @@ on:
       - ".github/workflows/**.yaml"
 
 jobs:
-  build-and-test:
+  # Check if any of the jobs have been run already (in a PR, for example)
+  pre_job:
+    # continue-on-error: true # Uncomment once integration is finished
     runs-on: ubuntu-latest
     outputs:
-      snap: ${{ steps.snapcraft.outputs.snap }}
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
 
-      - name: Build snap locally
-        uses: snapcore/action-build@v1
-        id: snapcraft
-
-      - name: Upload locally built snap artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: local-${{ steps.snapcraft.outputs.snap }}
-          path: ${{ steps.snapcraft.outputs.snap }}
-
-      - name: Install snap & invoke terraform
-        run: |
-          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
-          terraform --version
-
-      - name: Setup MicroK8s
-        uses: balchua/microk8s-actions@v0.2.1
-        with:
-          channel: latest/stable
-
-      - name: Test snap - kubernetes provider
-        run: |
-          cd test
-          terraform init
-          terraform apply -auto-approve
-          kubectl get ns snaptest
+  build-and-test:
+    # We might skip this job, if it was already run in a PR
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    outputs:
+      snap: ${{ steps.test.outputs.snap }}
+    steps:
+      - id: test
+        uses: ./.github/workflows/build-and-test.yaml
 
   # Uncomment when the snap confinement/plugs are configured
   publish:
@@ -54,25 +39,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install snapcraft
-        run: sudo snap install snapcraft --classic
-
-      - name: Remote build the snap
+      - name: Setup snapcraft
         env:
           LP_BUILD_SECRET: ${{ secrets.LP_BUILD_SECRET }}
+          STORE_LOGIN: ${{ secrets.STORE_LOGIN }}
         run: |
-          # Get the current version of the snap
-          VERSION="$(grep -Po "^version: \"\K[0-9]+\.[0-9]+\.[0-9]+" snap/snapcraft.yaml)"
+          # Install snapcraft
+          sudo snap install snapcraft --classic
+
+          # Login to snapcraft using saved credentials
+          echo "$STORE_LOGIN" > credentials.txt
+          snapcraft login --with credentials.txt
 
           # Setup Launchpad credentials
           mkdir -p ~/.local/share/snapcraft/provider/launchpad
           echo "$LP_BUILD_SECRET" > ~/.local/share/snapcraft/provider/launchpad/credentials
-
           git config --global user.email "github-actions@github.com"
           git config --global user.name "Github Actions"
 
-          # Remote build the snap
-          snapcraft remote-build --launchpad-accept-public-upload
+      - name: Remote build the snap
+        run: snapcraft remote-build --launchpad-accept-public-upload
 
       - name: Upload remote build snap artifacts and build logs
         uses: actions/upload-artifact@v3
@@ -83,12 +69,9 @@ jobs:
             **/*.txt
 
       - name: Upload and release (edge, candidate)
-        env:
-          STORE_LOGIN: ${{ secrets.STORE_LOGIN }}
         run: |
-          # Login to snapcraft using saved credentials
-          echo "$STORE_LOGIN" > credentials.txt
-          snapcraft login --with credentials.txt
+          # Get the current version of the snap
+          VERSION="$(grep -Po "^version: \"\K[0-9]+\.[0-9]+\.[0-9]+" snap/snapcraft.yaml)"
 
           # Upload the snaps and release to edge, candidate
           # TODO(jsngruk): Remove the `|| true` once uploads are approved 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "snap/snapcraft.yaml"
+      - ".github/workflows/**.yaml"
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     outputs:
       snap: ${{ steps.snapcraft.outputs.snap }}
@@ -14,41 +17,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Build snap
+      - name: Build snap locally
         uses: snapcore/action-build@v1
         id: snapcraft
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
+      - name: Upload locally built snap artifact
+        uses: actions/upload-artifact@v3
         with:
-          name: snap
+          name: local-${{ steps.snapcraft.outputs.snap }}
           path: ${{ steps.snapcraft.outputs.snap }}
 
-  test:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: snap
-
-      - name: Install snap
+      - name: Install snap & invoke terraform
         run: |
           sudo snap install --dangerous --classic ${{ needs.build.outputs.snap }}
-
-      - name: Basic test (invoke `terraform --version`)
-        run: terraform --version
+          terraform --version
 
       - name: Setup MicroK8s
         uses: balchua/microk8s-actions@v0.2.1
         with:
           channel: latest/stable
 
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Test snap (deploy on MicroK8s)
+      - name: Test snap - kubernetes provider
         run: |
           cd test
           terraform init
@@ -57,8 +46,9 @@ jobs:
 
   # Uncomment when the snap confinement/plugs are configured
   publish:
+    # Prevent this job from running concurrently so we don't spam launchpad
     concurrency: lp-remote-build
-    needs: [build, test]
+    needs: build-and-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -84,15 +74,24 @@ jobs:
           # Remote build the snap
           snapcraft remote-build --launchpad-accept-public-upload
 
-      # - name: Upload and release (edge, candidate)
-      #   env:
-      #     STORE_LOGIN: ${{ secrets.STORE_LOGIN }}
-      #   run: |
-      #     # Login to snapcraft using saved credentials
-      #     echo "$STORE_LOGIN" > credentials.txt
-      #     snapcraft login --with credentials.txt
+      - name: Upload remote build snap artifacts and build logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: remote-build-snaps
+          path: |
+            **/*.snap
+            **/*.txt
 
-      #     # Upload the snaps and release to edge, candidate
-      #     snapcraft upload --release edge,candidate "terraform_$VERSION_amd64.snap"
-      #     snapcraft upload --release edge,candidate "terraform_$VERSION_arm64.snap"
-      #     snapcraft upload --release edge,candidate "terraform_$VERSION_armhf.snap"
+      - name: Upload and release (edge, candidate)
+        env:
+          STORE_LOGIN: ${{ secrets.STORE_LOGIN }}
+        run: |
+          # Login to snapcraft using saved credentials
+          echo "$STORE_LOGIN" > credentials.txt
+          snapcraft login --with credentials.txt
+
+          # Upload the snaps and release to edge, candidate
+          # TODO(jsngruk): Remove the `|| true` once uploads are approved 
+          snapcraft upload --release edge,candidate "terraform_$VERSION_amd64.snap" || true
+          snapcraft upload --release edge,candidate "terraform_$VERSION_arm64.snap" || true
+          snapcraft upload --release edge,candidate "terraform_$VERSION_armhf.snap" || true

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,9 +4,12 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "snap/snapcraft.yaml"
+      - ".github/workflows/**.yaml"
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     outputs:
       snap: ${{ steps.snapcraft.outputs.snap }}
@@ -14,41 +17,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Build snap
+      - name: Build snap locally
         uses: snapcore/action-build@v1
         id: snapcraft
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
+      - name: Upload locally built snap artifact
+        uses: actions/upload-artifact@v3
         with:
-          name: snap
+          name: ${{ steps.snapcraft.outputs.snap }}
           path: ${{ steps.snapcraft.outputs.snap }}
 
-  test:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: snap
-
-      - name: Install snap
+      - name: Install snap & invoke terraform
         run: |
           sudo snap install --dangerous --classic ${{ needs.build.outputs.snap }}
-
-      - name: Basic test (invoke `terraform --version`)
-        run: terraform --version
+          terraform --version
 
       - name: Setup MicroK8s
         uses: balchua/microk8s-actions@v0.2.1
         with:
           channel: latest/stable
 
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Test snap (deploy on MicroK8s)
+      - name: Test snap - kubernetes provider
         run: |
           cd test
           terraform init
@@ -57,19 +46,19 @@ jobs:
 
   # Publishes the snap to a branch for QA purposes only
   publish:
-    needs: [build, test]
+    needs: build-and-test
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: snap
+          name: ${{ needs.build-and-test.outputs.snap }}
 
       - name: Release snap to branch
         uses: snapcore/action-publish@v1
         with:
           store_login: ${{ secrets.STORE_LOGIN }}
-          snap: ${{ needs.build.outputs.snap }}
+          snap: ${{ needs.build-and-test.outputs.snap }}
           release: edge/pr-${{ env.PR }}
         env:
           PR: ${{ github.event.number }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install snap & invoke terraform
         run: |
-          sudo snap install --dangerous --classic ${{ needs.build.outputs.snap }}
+          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
           terraform --version
 
       - name: Setup MicroK8s

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,39 +10,11 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
     outputs:
-      snap: ${{ steps.snapcraft.outputs.snap }}
+      snap: ${{ steps.test.outputs.snap }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build snap locally
-        uses: snapcore/action-build@v1
-        id: snapcraft
-
-      - name: Upload locally built snap artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ steps.snapcraft.outputs.snap }}
-          path: ${{ steps.snapcraft.outputs.snap }}
-
-      - name: Install snap & invoke terraform
-        run: |
-          sudo snap install --dangerous --classic ${{ steps.snapcraft.outputs.snap }}
-          terraform --version
-
-      - name: Setup MicroK8s
-        uses: balchua/microk8s-actions@v0.2.1
-        with:
-          channel: latest/stable
-
-      - name: Test snap - kubernetes provider
-        run: |
-          cd test
-          terraform init
-          terraform apply -auto-approve
-          kubectl get ns snaptest
+      - id: test
+        uses: ./.github/workflows/build-and-test.yaml
 
   # Publishes the snap to a branch for QA purposes only
   publish:


### PR DESCRIPTION
This PR refactors the CI setup (again) in an attempt to be clever about when the local build/deploy on microk8s action is run, to ensure it is only run once per commit hash. Before this, it would be run as part of a pull request, and then again once branches are merged - after this PR it should be clever enough to only run on the PR and skip when merged.