### PR TITLE
Fix auto-release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,7 +57,6 @@ jobs:
           VERSION="$(grep -Po "^version: \"\K[0-9]+\.[0-9]+\.[0-9]+" snap/snapcraft.yaml)"
 
           # Upload the snaps and release to edge, candidate
-          # TODO(jsngruk): Remove the `|| true` once uploads are approved 
-          snapcraft upload --release edge,candidate "terraform_$VERSION_amd64.snap" || true
-          snapcraft upload --release edge,candidate "terraform_$VERSION_arm64.snap" || true
-          snapcraft upload --release edge,candidate "terraform_$VERSION_armhf.snap" || true
+          snapcraft upload --release edge,candidate "terraform_${VERSION}_amd64.snap"
+          snapcraft upload --release edge,candidate "terraform_${VERSION}_arm64.snap"
+          snapcraft upload --release edge,candidate "terraform_${VERSION}_armhf.snap"


### PR DESCRIPTION
There was previously a get out that allowed the upload of snaps on merge to main to fail. Now that the snap is approved for publishing as `classic`, undo that so we can publish builds for `amd64`, `armhf` and `arm64`.