### PR TITLE
Add architectures and build from source

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,7 +57,8 @@ jobs:
           VERSION="$(grep -Po "^version: \"\K[0-9]+\.[0-9]+\.[0-9]+" snap/snapcraft.yaml)"
 
           # Upload the snaps and release to edge, candidate
-          # TODO(jsngruk): Remove the `|| true` once uploads are approved 
-          snapcraft upload --release edge,candidate "terraform_$VERSION_amd64.snap" || true
-          snapcraft upload --release edge,candidate "terraform_$VERSION_arm64.snap" || true
-          snapcraft upload --release edge,candidate "terraform_$VERSION_armhf.snap" || true
+          snapcraft upload --release edge,candidate "terraform_${VERSION}_amd64.snap"
+          snapcraft upload --release edge,candidate "terraform_${VERSION}_arm64.snap"
+          snapcraft upload --release edge,candidate "terraform_${VERSION}_armhf.snap"
+          snapcraft upload --release edge,candidate "terraform_${VERSION}_s390x.snap"
+          snapcraft upload --release edge,candidate "terraform_${VERSION}_ppc64el.snap"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,6 @@ apps:
 
 architectures:
   - build-on: amd64
-  - build-on: i386
   - build-on: armhf
   - build-on: arm64
   - build-on: s390x
@@ -27,6 +26,14 @@ parts:
   terraform:
     plugin: go
     source: https://github.com/hashicorp/terraform
+    source-type: git
     source-tag: "v$SNAPCRAFT_PROJECT_VERSION"
-    # stage:
-    #   - terraform
+    build-environment:
+      - CGO_ENABLED: "0"
+      - GOFLAGS: "-mod=readonly"
+    override-build: |
+      go mod download
+      go build -ldflags "-s -w"
+      cp terraform $SNAPCRAFT_PART_INSTALL/terraform
+    stage:
+      - terraform

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,14 +20,13 @@ architectures:
   - build-on: i386
   - build-on: armhf
   - build-on: arm64
+  - build-on: s390x
+  - build-on: ppc64el
 
 parts:
   terraform:
-    plugin: dump
-    source:
-      - on amd64: https://releases.hashicorp.com/terraform/$SNAPCRAFT_PROJECT_VERSION/terraform_$SNAPCRAFT_PROJECT_VERSION_linux_amd64.zip
-      - on i386: https://releases.hashicorp.com/terraform/$SNAPCRAFT_PROJECT_VERSION/terraform_$SNAPCRAFT_PROJECT_VERSION_linux_386.zip
-      - on armhf: https://releases.hashicorp.com/terraform/$SNAPCRAFT_PROJECT_VERSION/terraform_$SNAPCRAFT_PROJECT_VERSION_linux_arm.zip
-      - on arm64: https://releases.hashicorp.com/terraform/$SNAPCRAFT_PROJECT_VERSION/terraform_$SNAPCRAFT_PROJECT_VERSION_linux_arm64.zip
-    stage:
-      - terraform
+    plugin: go
+    source: https://github.com/hashicorp/terraform
+    source-tag: "v$SNAPCRAFT_PROJECT_VERSION"
+    # stage:
+    #   - terraform


### PR DESCRIPTION
This PR makes two changes:

- Add support for `ppc64el` and `s390x` architectures
- Build `terraform` from source using the `go` plugin (required to support `s390x` and `ppc64el` as Hashicorp do not provide builds for these architectures)