### PR TITLE
Bump the snap base to core22

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Build snap locally
         uses: snapcore/action-build@v1
         id: snapcraft
+        snapcraft-channel: 7.x/candidate
 
       - name: Upload locally built snap artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,7 +19,8 @@ jobs:
       - name: Build snap locally
         uses: snapcore/action-build@v1
         id: snapcraft
-        snapcraft-channel: 7.x/candidate
+        with:
+          snapcraft-channel: 7.x/candidate
 
       - name: Upload locally built snap artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ jobs:
           STORE_LOGIN: ${{ secrets.STORE_LOGIN }}
         run: |
           # Install snapcraft
-          sudo snap install snapcraft --classic
+          sudo snap install snapcraft --classic --channel=7.x/candidate
 
           # Login to snapcraft using saved credentials
           echo "$STORE_LOGIN" > credentials.txt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,13 +32,16 @@ parts:
     plugin: go
     source: https://github.com/hashicorp/terraform
     source-type: git
-    source-tag: "v$SNAPCRAFT_PROJECT_VERSION"
+    override-pull: |
+      VERSION="$(craftctl get version)"
+      git clone -b "v$VERSION" https://github.com/hashicorp/terraform $CRAFT_PART_SRC
+    build-snaps: [go]
     build-environment:
       - CGO_ENABLED: "0"
       - GOFLAGS: "-mod=readonly"
     override-build: |
       go mod download
       go build -ldflags "-s -w"
-      cp terraform $SNAPCRAFT_PART_INSTALL/terraform
+      cp terraform $CRAFT_PART_INSTALL/terraform
     stage:
       - terraform

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
   infrastructure. It is an open source tool that codifies APIs into
   declarative configuration files that can be shared amongst team members,
   treated as code, edited, reviewed, and versioned.
-base: core20
+base: core22
 grade: stable
 confinement: classic
 compression: lzo


### PR DESCRIPTION
Upgrade base from `core20` to `core22` - need to use `snapcraft` from `7.x/candidate` until released into `stable`.