### PR TITLE
fix: set correct version during go build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,9 +37,13 @@ parts:
     build-environment:
       - CGO_ENABLED: "0"
       - GOFLAGS: "-mod=readonly"
+      - LDFLAGS: "-s -w"
     override-build: |
+      export LDFLAGS="${LDFLAGS} -X 'github.com/hashicorp/terraform/version.Prerelease='"
+      export LDFLAGS="${LDFLAGS} -X 'github.com/hashicorp/terraform/version.Version=$(cat version/VERSION)'"
+
       go mod download
-      go build -ldflags "-s -w"
+      go build -ldflags "${LDFLAGS}"
       cp terraform $SNAPCRAFT_PART_INSTALL/terraform
     stage:
       - terraform


### PR DESCRIPTION
The `go build` process was not setting the version correctly, meaning that Terraform 1.4.4 reported as `1.4.3-dev` when build, meaning the client was reporting there was an update available, when in fact there was not.

This fix uses `ldflags` to set the version correctly and build a "release" version.

Fixes #61