### PR TITLE
ci: ignore release candidate versions in sync-version-with-upstream

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -24,6 +24,6 @@ jobs:
           update-script: |
             VERSION=$(
               curl -sL https://api.github.com/repos/hashicorp/terraform/releases |
-              jq .  | grep tag_name | grep -v beta | grep -v alpha | head -n 1 | cut -d'"' -f4 | tr -d 'v'
+              jq -r '.[].tag_name' | grep -m1 -vE 'alpha|beta|rc' | tr -d 'v'
             )
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml


### PR DESCRIPTION
This PR ensures that the automation ignores release candidate versions. Recently the 1.7.0 RC was released, and was [released to candidate by this commit](https://github.com/snapcrafters/terraform/commit/b38728618547dcc5df5502c6211457d82657bc16).

Here we ignore anything with `alpha`, `beta` and `rc` in the tag name, and simplify the bash pipeline a little in the process.