### PR TITLE
chore: migrate to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ description: |
 
   This snap is maintained by the Snapcrafters community, and is not
   necessarily endorsed or officially maintained by the upstream developers.
-base: core22
+base: core24
 grade: stable
 confinement: classic
 compression: lzo
@@ -31,12 +31,12 @@ apps:
   terraform:
     command: terraform
 
-architectures:
-  - build-on: amd64
-  - build-on: armhf
-  - build-on: arm64
-  - build-on: s390x
-  - build-on: ppc64el
+platforms:
+  amd64:
+  armhf:
+  arm64:
+  s390x:
+  ppc64el:
 
 parts:
   terraform:


### PR DESCRIPTION
Migrate the snap to `core24` - mostly to test the CI changes by @NucciTheBoss!