### PR TITLE
feat: add content slot for Terraform binary

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,6 +27,14 @@ confinement: classic
 compression: lzo
 icon: snap/gui/terraform.png
 
+# 'content' slot for allowing other snaps to use the Terraform binary
+slots:
+  terraform:
+    interface: content
+    content: terraform-binary
+    read:
+      - $SNAP
+
 apps:
   terraform:
     command: terraform


### PR DESCRIPTION
Motivated by the creation of the Terragrunt snap (github.com/snapcrafters/terragrunt), the intent is to allow a snap with strict confinement (like `terragrunt`) to be able to use the Terraform binary without having to ship Terraform itself or having to become a `classic` snap.